### PR TITLE
Exceptions Best Practices

### DIFF
--- a/scheme.cabal
+++ b/scheme.cabal
@@ -18,19 +18,18 @@ library
     OverloadedStrings
 
   build-depends:       
-    base           >= 4.8 && <5.0,
-    mtl            >= 2.2 && <2.3,
-    parsec         >= 3.1 && <3.2,
-    containers     >= 0.5 && <0.6,
-    wl-pprint-text >= 1.1 && <1.2,
-    text           >= 1.2 && <1.3,
-    transformers   >= 0.4 && <0.6,
-    haskeline      >= 0.7 && <0.8,
-    mtl            >= 2.2.1, 
-    directory -any,
-    exceptions -any,
-    resourcet -any, 
-    optparse-applicative -any
+    base                 >= 4.8 && <5.0,
+    containers           >= 0.5 && <0.6,
+    directory            >= 1.2 && <1.3,
+    exceptions           >= 0.8 && <0.9,
+    haskeline            >= 0.7 && <0.8,
+    mtl                  >= 2.2 && <2.3,
+    optparse-applicative >= 0.12 && < 0.13,
+    parsec               >= 3.1 && <3.2,
+    resourcet            >= 1.1 && <1.2, 
+    text                 >= 1.2 && <1.3,
+    transformers         >= 0.4 && <0.6,
+    wl-pprint-text       >= 1.1 && <1.2
  
   hs-source-dirs: src
   default-language: Haskell2010

--- a/scheme.cabal
+++ b/scheme.cabal
@@ -28,8 +28,10 @@ library
     haskeline      >= 0.7 && <0.8,
     mtl            >= 2.2.1, 
     directory -any,
+    exceptions -any,
+    resourcet -any, 
     optparse-applicative -any
-
+ 
   hs-source-dirs: src
   default-language: Haskell2010
 

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -18,7 +18,7 @@ import System.Directory
 import System.IO
 import Control.Monad.Except
 import Control.Monad.Reader
-
+import Control.Monad.Trans.Resource
 
 basicEnv :: Map.Map T.Text LispVal
 basicEnv = Map.fromList $ primEnv
@@ -31,9 +31,10 @@ readFn x = do
     (String txt) -> textToEvalForm txt
     _            -> throwError $ TypeMismatch "read expects string, instead got: " val
 
+
 runASTinEnv :: EnvCtx -> Eval b -> ExceptT LispError IO b
 runASTinEnv code action = do
-    res <- liftIO $ runExceptT $ runReaderT (unEval action) code
+    res <- liftIO $  runResourceT $ runExceptT $ runReaderT (unEval action) code
     ExceptT $ return res
 
 evalText :: T.Text -> IO () --REPL

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
 module Eval (
    evalText
   , evalFile
   , runParseTest
+  , safeExec
 ) where
 
 import Parser
@@ -19,6 +21,7 @@ import System.IO
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.Trans.Resource
+import Control.Exception
 
 basicEnv :: Map.Map T.Text LispVal
 basicEnv = Map.fromList $ primEnv
@@ -29,29 +32,34 @@ readFn x = do
   val <- eval x
   case val of
     (String txt) -> textToEvalForm txt
-    _            -> throwError $ TypeMismatch "read expects string, instead got: " val
+    _            -> throwM $ TypeMismatch "read expects string, instead got: " val
 
 
-runASTinEnv :: EnvCtx -> Eval b -> ExceptT LispError IO b
-runASTinEnv code action = do
-    res <- liftIO $  runResourceT $ runExceptT $ runReaderT (unEval action) code
-    ExceptT $ return res
+safeExec :: IO a -> IO (Either String a)
+safeExec m = do 
+  result <- Control.Exception.try m
+  case result of
+    Left (eTop :: SomeException) -> 
+      case fromException eTop of
+        Just (enclosed :: LispError) -> return $ Left (show enclosed)
+        Nothing                -> return $ Left (show eTop)
+    Right val -> return $ Right val
+
+runASTinEnv :: EnvCtx -> Eval b -> IO b
+runASTinEnv code action = runResourceT $  runReaderT (unEval action) code
 
 evalText :: T.Text -> IO () --REPL
-evalText textExpr = do
-  out <- runExceptT $ runASTinEnv basicEnv $ textToEvalForm textExpr
-  either print print out
+evalText textExpr = (runASTinEnv basicEnv $ textToEvalForm textExpr) >>= print
+
 
 textToEvalForm :: T.Text -> Eval LispVal
-textToEvalForm input = either (throwError . PError . show  )  eval $ readExpr input
+textToEvalForm input = either (throwM . PError . show  )  eval $ readExpr input
 
 evalFile :: T.Text -> IO () --program file
-evalFile fileExpr = do
-  out <- runExceptT $ runASTinEnv basicEnv $ fileToEvalForm fileExpr
-  either print print out
+evalFile fileExpr = (runASTinEnv basicEnv $ fileToEvalForm fileExpr) >>= print
 
 fileToEvalForm :: T.Text -> Eval LispVal
-fileToEvalForm input = either (throwError . PError . show )  evalBody $ readExprFile input
+fileToEvalForm input = either (throwM . PError . show )  evalBody $ readExprFile input
 
 runParseTest :: T.Text -> T.Text -- for view AST
 runParseTest input = either (T.pack . show) (T.pack . show) $ readExpr input
@@ -61,12 +69,12 @@ getVar (Atom atom) = do
   env <- ask
   case Map.lookup atom env of
       Just x  -> return x
-      Nothing -> throwError $ UnboundVar atom
-getVar n = throwError $ TypeMismatch  "failure to get variable: " n
+      Nothing -> throwM $ UnboundVar atom
+getVar n = throwM $ TypeMismatch  "failure to get variable: " n
 
 ensureAtom :: LispVal -> Eval LispVal
 ensureAtom n@(Atom _) = return  n
-ensureAtom n = throwError $ TypeMismatch "expected an atomic value" n
+ensureAtom n = throwM $ TypeMismatch "expected an atomic value" n
 
 extractVar :: LispVal -> T.Text
 extractVar (Atom atom) = atom
@@ -103,8 +111,8 @@ eval (List [Atom "if", pred, ant, cons]) = do
   case ifRes of
       (Bool True)  -> eval ant
       (Bool False) -> eval cons
-      _            -> throwError $ BadSpecialForm "if's first arg must eval into a boolean"
-eval args@(List ( (:) (Atom "if") _))  = throwError $ BadSpecialForm "(if <bool> <s-expr> <s-expr>)"
+      _            -> throwM $ BadSpecialForm "if's first arg must eval into a boolean"
+eval args@(List ( (:) (Atom "if") _))  = throwM $ BadSpecialForm "(if <bool> <s-expr> <s-expr>)"
 
 eval (List [Atom "begin", rest]) = evalBody rest
 eval (List ((:) (Atom "begin") rest )) = evalBody $ List rest
@@ -120,12 +128,12 @@ eval (List [Atom "let", List pairs, expr]) = do
   atoms <- mapM ensureAtom $ getEven pairs
   vals  <- mapM eval       $ getOdd  pairs
   local (const (Map.fromList (Prelude.zipWith (\a b -> (extractVar a, b)) atoms vals) <> env))  $ evalBody expr
-eval (List (Atom "let":_) ) = throwError $ BadSpecialForm "lambda funciton expects list of parameters and S-Expression body\n(let <pairs> <s-expr>)" 
+eval (List (Atom "let":_) ) = throwM $ BadSpecialForm "lambda funciton expects list of parameters and S-Expression body\n(let <pairs> <s-expr>)" 
 
 eval (List [Atom "lambda", List params, expr]) = do 
   envLocal <- ask
   return  $ Lambda (IFunc $ applyLambda expr params) envLocal
-eval (List (Atom "lambda":_) ) = throwError $ BadSpecialForm "lambda funciton expects list of parameters and S-Expression body\n(lambda <params> <s-expr>)" 
+eval (List (Atom "lambda":_) ) = throwM $ BadSpecialForm "lambda funciton expects list of parameters and S-Expression body\n(lambda <params> <s-expr>)" 
 
 eval (List ((:) x xs)) = do 
   funVar <- eval x
@@ -133,9 +141,9 @@ eval (List ((:) x xs)) = do
   case funVar of
       (Fun (IFunc internalFn)) -> internalFn xVal
       (Lambda (IFunc internalfn) boundenv) -> local (const boundenv) $ internalfn xVal
-      _                -> throwError $ NotFunction funVar 
+      _                -> throwM $ NotFunction funVar 
 
-eval x = throwError $ Default  x --fall thru
+eval x = throwM $ Default  x --fall thru
 
 evalBody :: LispVal -> Eval LispVal
 evalBody (List [List ((:) (Atom "define") [Atom var, defExpr]), rest]) = do 

--- a/src/LispVal.hs
+++ b/src/LispVal.hs
@@ -12,6 +12,10 @@ import Control.Monad.Reader
 import Control.Monad.Catch
 import Control.Monad.Trans.Resource
 
+
+import Data.Data
+import Data.Typeable
+
 type EnvCtx = Map.Map T.Text LispVal
 -- EnvCtx -> ExceptT LispError IO a
 newtype Eval a = Eval { unEval :: ReaderT EnvCtx (ResourceT IO) a }
@@ -25,12 +29,12 @@ data LispVal
   | Fun IFunc
   | Lambda IFunc EnvCtx
   | Nil
-  | Bool Bool
+  | Bool Bool deriving (Typeable)
 
 instance Show LispVal where
   show = T.unpack . showVal
 
-data IFunc = IFunc { fn :: [LispVal] -> Eval LispVal }
+data IFunc = IFunc { fn :: [LispVal] -> Eval LispVal } deriving (Typeable)
 
 
 showVal :: LispVal -> T.Text
@@ -61,7 +65,7 @@ data LispError
   | UnboundVar T.Text
   | Default LispVal
   | PError String -- from show anyway
-  | IOError T.Text deriving (Data, Typeable) 
+  | IOError T.Text deriving ( Typeable) 
 
 instance Exception LispError
 

--- a/src/Prim.hs
+++ b/src/Prim.hs
@@ -5,102 +5,126 @@ module Prim where
 import LispVal
 
 import Data.Text as T
+import Data.Text.IO as TIO
 import Data.Monoid
 import Control.Monad.Except
+import Control.Monad.Catch
 import Control.Monad.Reader
 import System.Directory
 import System.IO
 import System.Environment
 
+
 type Prim   = [(T.Text, LispVal)]
 type Unary  = LispVal -> Eval LispVal
 type Binary = LispVal -> LispVal -> Eval LispVal
 
+
+mkF :: ([LispVal] -> Eval LispVal) -> LispVal 
+mkF = Fun . IFunc
+
+
+
 primEnv :: Prim
-primEnv = [   ("+"    , Fun $ IFunc $ binopFold (numOp    (+))  (Number 0) )
-            , ("*"    , Fun $ IFunc $ binopFold (numOp    (*))  (Number 1) )
-            , ("++"   , Fun $ IFunc $ binopFold (strOp    (<>)) (String ""))
-            , ("-"    , Fun $ IFunc $ binop $    numOp    (-))
-            , ("<"    , Fun $ IFunc $ binop $    numCmp   (<))
-            , ("<="   , Fun $ IFunc $ binop $    numCmp   (<=))
-            , (">"    , Fun $ IFunc $ binop $    numCmp   (>))
-            , (">="   , Fun $ IFunc $ binop $    numCmp   (>=))
-            , ("=="   , Fun $ IFunc $ binop $    numCmp   (==))
-            , ("even?", Fun $ IFunc $ unop $     numBool   even)
-            , ("odd?" , Fun $ IFunc $ unop $     numBool   odd)
-            , ("pos?" , Fun $ IFunc $ unop $     numBool (< 0))
-            , ("neg?" , Fun $ IFunc $ unop $     numBool (> 0))
-            , ("eq?"  , Fun $ IFunc $ binop  eqCmd )
-            , ("bl-eq?",Fun $ IFunc $ binop $ eqOp     (==))
-            , ("and"  , Fun $ IFunc $ binopFold (eqOp     (&&)) (Bool True))
-            , ("or"   , Fun $ IFunc $ binopFold (eqOp     (||)) (Bool False))
-            , ("cons" , Fun $ IFunc  Prim.cons)
-            , ("cdr"  , Fun $ IFunc  Prim.cdr)
-            , ("car"  , Fun $ IFunc  Prim.car)
-            , ("quote", Fun $ IFunc  quote)
-            , ("file?" , Fun $ IFunc $ unop  fileExists)
-            , ("slurp" , Fun $ IFunc $ unop  slurp)
+primEnv = [   ("+"    , mkF $ binopFold (numOp    (+))  (Number 0) )
+            , ("*"    , mkF $ binopFold (numOp    (*))  (Number 1) )
+            , ("++"   , mkF $ binopFold (strOp    (<>)) (String ""))
+            , ("-"    , mkF $ binop $    numOp    (-))
+            , ("<"    , mkF $ binop $    numCmp   (<))
+            , ("<="   , mkF $ binop $    numCmp   (<=))
+            , (">"    , mkF $ binop $    numCmp   (>))
+            , (">="   , mkF $ binop $    numCmp   (>=))
+            , ("=="   , mkF $ binop $    numCmp   (==))
+            , ("even?", mkF $ unop $     numBool   even)
+            , ("odd?" , mkF $ unop $     numBool   odd)
+            , ("pos?" , mkF $ unop $     numBool (< 0))
+            , ("neg?" , mkF $ unop $     numBool (> 0))
+            , ("eq?"  , mkF $ binop  eqCmd )
+            , ("bl-eq?",mkF $ binop $ eqOp     (==))
+            , ("and"  , mkF $ binopFold (eqOp     (&&)) (Bool True))
+            , ("or"   , mkF $ binopFold (eqOp     (||)) (Bool False))
+            , ("cons" , mkF  Prim.cons)
+            , ("cdr"  , mkF  Prim.cdr)
+            , ("car"  , mkF  Prim.car)
+            , ("quote", mkF  quote)
+            , ("file?" , mkF $ unop  fileExists)
+            , ("slurp" , mkF $ unop  slurp)
             ]
 
 unop :: Unary -> [LispVal] -> Eval LispVal
 unop op [x]    = op x
-unop _ args    = throwError $ NumArgs 1 args
+unop _ args    = throwM $ NumArgs 1 args
 
 binop :: Binary -> [LispVal] -> Eval LispVal
 binop op [x,y]  = op x y
-binop _  args   = throwError $ NumArgs 2 args
+binop _  args   = throwM $ NumArgs 2 args
 
 fileExists :: LispVal  -> Eval LispVal
 fileExists (Atom atom)  = fileExists $ String atom
 fileExists (String txt) = Bool <$> liftIO (doesFileExist $ T.unpack txt)
-fileExists val          = throwError $ TypeMismatch "read expects string, instead got: " val
+fileExists val          = throwM $ TypeMismatch "read expects string, instead got: " val
 
 slurp :: LispVal  -> Eval LispVal
-slurp (String txt) = readTextFile txt
-slurp val          =  throwError $ TypeMismatch "read expects string, instead got: " val
+slurp (String txt) = liftIO $ wFileSlurp txt
+slurp val          =  throwM $ TypeMismatch "read expects string, instead got: " val
 
+{-
 readTextFile ::  T.Text -> Eval LispVal
 readTextFile file =  do
   inHandle   <- liftIO $ openFile (T.unpack file) ReadMode
   ineof <- liftIO $ hIsEOF inHandle
   if ineof
-    then  throwError $ IOError "empty file"
-      else do fileText <- liftIO $ hGetContents  inHandle
-              return $ String $ T.pack fileText
+    then  throwM $ IOError "empty file"
+      else do fileText <- liftIO $ TIO.hGetContents  inHandle
+              return $ String $ fileText
+-}
+
+wFileSlurp :: T.Text -> IO LispVal 
+wFileSlurp fileName = withFile (T.unpack fileName) ReadMode go
+  where go = readTextFile fileName
+
+
+readTextFile :: T.Text -> Handle -> IO LispVal
+readTextFile fileName handle = do
+  exists <- hIsEOF handle
+  if exists
+  then (TIO.hGetContents handle) >>= (return . String)
+  else throwM $ IOError $ T.concat [" file does not exits: ", fileName]
+
 
 binopFold :: Binary -> LispVal -> [LispVal] -> Eval LispVal
 binopFold op farg args = case args of
                             [a,b]  -> op a b
                             (a:as) -> foldM op farg args
-                            []-> throwError $ NumArgs 2 args
+                            []-> throwM $ NumArgs 2 args
 
 numBool :: (Integer -> Bool) -> LispVal -> Eval LispVal
 numBool op (Number x) = return $ Bool $ op x
-numBool op  x         = throwError $ TypeMismatch "numeric op " x
+numBool op  x         = throwM $ TypeMismatch "numeric op " x
 
 numOp :: (Integer -> Integer -> Integer) -> LispVal -> LispVal -> Eval LispVal
 numOp op (Number x) (Number y) = return $ Number $ op x  y
-numOp op x          (Number y) = throwError $ TypeMismatch "numeric op " x
-numOp op (Number x)  y         = throwError $ TypeMismatch "numeric op " y
-numOp op x           y         = throwError $ TypeMismatch "numeric op " x
+numOp op x          (Number y) = throwM $ TypeMismatch "numeric op " x
+numOp op (Number x)  y         = throwM $ TypeMismatch "numeric op " y
+numOp op x           y         = throwM $ TypeMismatch "numeric op " x
 
 strOp :: (T.Text -> T.Text -> T.Text) -> LispVal -> LispVal -> Eval LispVal
 strOp op (String x) (String y) = return $ String $ op x y
-strOp op x          (String y) = throwError $ TypeMismatch "string op " x
-strOp op (String x)  y         = throwError $ TypeMismatch "string op " y
-strOp op x           y         = throwError $ TypeMismatch "string op " x
+strOp op x          (String y) = throwM $ TypeMismatch "string op " x
+strOp op (String x)  y         = throwM $ TypeMismatch "string op " y
+strOp op x           y         = throwM $ TypeMismatch "string op " x
 
 eqOp :: (Bool -> Bool -> Bool) -> LispVal -> LispVal -> Eval LispVal
 eqOp op (Bool x) (Bool y) = return $ Bool $ op x y
-eqOp op  x       (Bool y) = throwError $ TypeMismatch "bool op " x
-eqOp op (Bool x)  y       = throwError $ TypeMismatch "bool op " y
-eqOp op x         y       = throwError $ TypeMismatch "bool op " x
+eqOp op  x       (Bool y) = throwM $ TypeMismatch "bool op " x
+eqOp op (Bool x)  y       = throwM $ TypeMismatch "bool op " y
+eqOp op x         y       = throwM $ TypeMismatch "bool op " x
 
 numCmp :: (Integer -> Integer -> Bool) -> LispVal -> LispVal -> Eval LispVal
 numCmp op (Number x) (Number y) = return . Bool $ op x  y
-numCmp op x          (Number y) = throwError $ TypeMismatch "numeric op " x
-numCmp op (Number x)  y         = throwError $ TypeMismatch "numeric op " y
-numCmp op x         y           = throwError $ TypeMismatch "numeric op " x
+numCmp op x          (Number y) = throwM $ TypeMismatch "numeric op " x
+numCmp op (Number x)  y         = throwM $ TypeMismatch "numeric op " y
+numCmp op x         y           = throwM $ TypeMismatch "numeric op " x
 
 
 eqCmd :: LispVal -> LispVal -> Eval LispVal 
@@ -115,25 +139,25 @@ cons :: [LispVal] -> Eval LispVal
 cons [x,y@(List yList)] = return $ List $ x:yList
 cons [c]                = return $ List [c]
 cons []                 = return $ List []
-cons _  = throwError $ ExpectedList "cons, in second argumnet"
+cons _  = throwM $ ExpectedList "cons, in second argumnet"
 
 car :: [LispVal] -> Eval LispVal
 car [List []    ] = return Nil
 car [List (x:_)]  = return x
 car []            = return Nil
-car x             = throwError $ ExpectedList "car"
+car x             = throwM $ ExpectedList "car"
 
 cdr :: [LispVal] -> Eval LispVal
 cdr [List (x:xs)] = return $ List xs
 cdr [List []]     = return Nil
 cdr []            = return Nil
-cdr x             = throwError $ ExpectedList "cdr"
+cdr x             = throwM $ ExpectedList "cdr"
 
 quote :: [LispVal] -> Eval LispVal
 quote [List xs]   = return $ List $ Atom "quote" : xs
 quote [exp]       = return $ List $ Atom "quote" : [exp]
 
--- default return to Eval monad (no error handling)
+-- default return to Eval monad (no throwM handling)
 binopFixPoint :: (LispVal -> LispVal -> LispVal) -> [LispVal] -> Eval LispVal
 binopFixPoint f2 = binop (\x y -> return $ f2 x y)
 

--- a/src/Repl.hs
+++ b/src/Repl.hs
@@ -13,7 +13,9 @@ import System.Console.Haskeline
 type Repl a = InputT IO a
 
 process :: String -> IO ()
-process str = evalText $ T.pack str
+process str = do 
+  res <- safeExec $ evalText $ T.pack str
+  either putStrLn return res
 
 processToAST :: String -> IO ()
 processToAST str = print $ runParseTest $ T.pack str


### PR DESCRIPTION
Eval monad fix to removes 'ExceptT LispError (IO a)" anti-pattern. Replace with monadThrow and monadCatch. Shore up IO w/ ResourceT monad. 