### PR TITLE
Fix broken example expression in docs/00-overview.md `begin` section

### DIFF
--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -99,7 +99,7 @@ The `if` statement acts like it does in any language.
 
 **Begin**    
 `begin` evaluates a series of one or more S-Expressions in order.  S-Expressions can modify the environment using `define`, then subsequent expressions may access the modified environment.  Further, when running a Scheme program, its S-Expressions are essentially wrapped in a single begin function.  More on this when we go over [Eval.hs](https://github.com/write-you-a-scheme-v2/scheme/tree/master/src/Eval.hs).     
-`(begin (define x 413000) (define y (+ x 281)) (+ x y))` => `413281`    
+`(begin (define x 413000) (define y 281) (+ x y))` => `413281`    
 
 **The Rest**    
 

--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -99,7 +99,7 @@ The `if` statement acts like it does in any language.
 
 **Begin**    
 `begin` evaluates a series of one or more S-Expressions in order.  S-Expressions can modify the environment using `define`, then subsequent expressions may access the modified environment.  Further, when running a Scheme program, its S-Expressions are essentially wrapped in a single begin function.  More on this when we go over [Eval.hs](https://github.com/write-you-a-scheme-v2/scheme/tree/master/src/Eval.hs).     
-`(begin (define x 413000) (define y 281) (+ x y))` => `413281`    
+`(begin (define x 413000) (define y (+ x 281)) (+ x y))` => `826281`    
 
 **The Rest**    
 


### PR DESCRIPTION
Hi there,

I noticed the `begin` expression in `docs/00-overview.md` was incorrect so I've fixed it.

```scheme
=> (begin (define x 413000) (define y (+ x 281)) (+ x y))
;Value: 826281

=> (begin (define x 413000) (define y 281) (+ x y))
;Value: 413281
```

The former is of course the result of `413000 + (413000 + 281)` whereas the latter matches the `413281` value indicated.

Thanks for making this guide! I'm enjoying it.
Matt