### PR TITLE
Fix interpreter paths for NixOS by using /usr/bin/env

### DIFF
--- a/build
+++ b/build
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 stack build --fast --file-watch 

--- a/repl
+++ b/repl
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 stack build
 stack exec scheme -- -r

--- a/run
+++ b/run
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 stack build
 stack exec scheme -- "$@"


### PR DESCRIPTION
NixOS does not have absolute FHS paths, so the `/bin/bash` shebangs in `run`, `repl`, and `build` do not work. This small patch fixes this without breaking anything. 