### PR TITLE
Fix type error in function application

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -203,7 +203,7 @@ eval all@(List ((:) x xs)) = do
   funVar <- eval x
   --liftIO $ TIO.putStr $ T.concat ["eval:\n  ", T.pack $ show all,"\n  * fnCall:  ", T.pack $ show x, "\n  * fnVar  ", T.pack $ show funVar,"\n  * args:  ",T.concat (T.pack . show <$> xVal)    ,T.pack "\n"]
   case funVar of
-      (Fun (IFunc internalFn)) -> mapM eval xs >>= internalFn xVal
+      (Fun (IFunc internalFn)) -> mapM eval xs >>= internalFn 
       (Lambda (IFunc definedFn) boundenv) -> local (const (boundenv <> env)) $ definedFn xs
 
       _                -> throw $ NotFunction funVar


### PR DESCRIPTION
Fixes a type error in `Eval.hs`:

```
$ ./repl

...
/scheme/src/Eval.hs:206:52: error:
    • Couldn't match expected type ‘[LispVal] -> Eval LispVal’
                  with actual type ‘Eval LispVal’
    • Possible cause: ‘internalFn’ is applied to too many arguments
      In the second argument of ‘(>>=)’, namely ‘internalFn xVal’
      In the expression: mapM eval xs >>= internalFn xVal
      In a case alternative:
          (Fun (IFunc internalFn)) -> mapM eval xs >>= internalFn xVal

/scheme/src/Eval.hs:206:63: error: Variable not in scope: xVal :: [LispVal]

--  While building package scheme-0.1 using:
      [...].stack/setup-exe-cache/x86_64-osx/Cabal-simple_mPHDZzAJ_1.24.0.0_ghc-8.0.1 --builddir=.stack-work/dist/x86_64-osx/Cabal-1.24.0.0 build lib:scheme exe:docs exe:scheme --ghc-options " -ddump-hi -ddump-to-file"
    Process exited with code: ExitFailure 1
```

Project builds and tests pass with this change.