### PR TITLE
Fix arg scoping

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -126,8 +126,7 @@ getOdd (x:xs) = getEven xs
 applyLambda :: LispVal -> [LispVal] -> [LispVal] -> Eval LispVal
 applyLambda expr params args = do
   env <- ask
-  argEval <- mapM eval args
-  local (const ((Map.fromList (zipWith (\a b -> (extractVar a,b)) params argEval)) <> env)) $ eval expr
+  local (const ((Map.fromList (zipWith (\a b -> (extractVar a,b)) params args)) <> env)) $ eval expr
 
 
 eval :: LispVal -> Eval LispVal
@@ -201,10 +200,11 @@ eval all@(List [Atom "car", arg@(List (x:xs))]) =
 eval all@(List ((:) x xs)) = do
   env    <- ask
   funVar <- eval x
+  xVal <- mapM eval xs
   --liftIO $ TIO.putStr $ T.concat ["eval:\n  ", T.pack $ show all,"\n  * fnCall:  ", T.pack $ show x, "\n  * fnVar  ", T.pack $ show funVar,"\n  * args:  ",T.concat (T.pack . show <$> xVal)    ,T.pack "\n"]
   case funVar of
-      (Fun (IFunc internalFn)) -> mapM eval xs >>= internalFn 
-      (Lambda (IFunc definedFn) boundenv) -> local (const (boundenv <> env)) $ definedFn xs
+      (Fun (IFunc internalFn)) -> internalFn xVal
+      (Lambda (IFunc definedFn) boundenv) -> local (const (boundenv <> env)) $ definedFn xVal
 
       _                -> throw $ NotFunction funVar
 

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -203,7 +203,7 @@ eval all@(List ((:) x xs)) = do
   funVar <- eval x
   --liftIO $ TIO.putStr $ T.concat ["eval:\n  ", T.pack $ show all,"\n  * fnCall:  ", T.pack $ show x, "\n  * fnVar  ", T.pack $ show funVar,"\n  * args:  ",T.concat (T.pack . show <$> xVal)    ,T.pack "\n"]
   case funVar of
-      (Fun (IFunc internalFn)) -> mapM eval xs >>= internalFn xVal
+      (Fun (IFunc internalFn)) -> mapM eval xs >>= internalFn 
       (Lambda (IFunc definedFn) boundenv) -> local (const (boundenv <> env)) $ definedFn xs
 
       _                -> throw $ NotFunction funVar

--- a/test-hs/Spec.hs
+++ b/test-hs/Spec.hs
@@ -93,6 +93,7 @@ main = do
     wStd "test/test_cadadr.scm"      $ Number 42
     wStd "test/test_gt.scm"          $ List [ Bool True, Bool False]
     wStd "test/test_scope1.scm"      $ Number 413281
+    wStd "test/test_scope2.scm"      $ Number 11
     wStd "test/test_args.scm"        $ Number 105065
     wStd "test/test_fold.scm"        $ Number 42
     runExpr Nothing "test/define.scm"        $ Number 4

--- a/test/test_scope2.scm
+++ b/test/test_scope2.scm
@@ -1,0 +1,4 @@
+(begin
+  (define y 1)
+  (define add (lambda (x) (+ x y)))
+  (let (y 10) (add y)))


### PR DESCRIPTION
Fixes #23 and #25, evaluating function arguments in the correct scope. This is an alternative to #30, it fixes the build and passes all tests. 
