### PR TITLE
Remove typeable, filenames cleanup in Introduction

### DIFF
--- a/docs/01_introduction.md
+++ b/docs/01_introduction.md
@@ -26,13 +26,13 @@ This may seem like a lot.  But don't worry, all these things, and more, are alre
 
 <img src="/img/WYAS-Dependency-Tree.png" style="height:auto; width:70%;">
 
-* **Main.hs** Handles the creation of the binary executable, parsing of command line options.
+* **Main.hs** Handles the creation of the binary executable.
+* **Cli.hs** Parsing of command line options, command line interface.
 * **Repl.hs** Read Evaluate Print Loop code.
 * **Parser.hs** Lexer and Parser using Parsec code. Responsibility for the creation of LispVal object from Text input.
 * **Eval.hs** Contains the evaluation function, `eval`. Patten matches on all configurations of S-Expressions and computes the resultant `LispVal`.
 * **LispVal.hs** defines LispVal, evaluation monad, LispException, and report printing functions.
-* **Prims.hs** Creates the primitive environment functions, which themselves are contained in a map.  These primitive functions are Haskell functions mapped to `LispVal`s.
-* **Pretty.hs** Pretty Printer, used for formatting error messages. Might drop this, what do you think?
+* **Prim.hs** Creates the primitive environment functions, which themselves are contained in a map.  These primitive functions are Haskell functions mapped to `LispVal`s.
 
 ## An Engineering Preface
 Before we start, there is a note I have to make on efficient memory usage Haskell.

--- a/docs/01_introduction.md
+++ b/docs/01_introduction.md
@@ -73,7 +73,7 @@ data LispVal
   | Fun IFunc
   | Lambda IFunc EnvCtx
   | Nil
-  | Bool Bool deriving (Typeable)
+  | Bool Bool deriving (Eq)
 
 data IFunc = IFunc { fn :: [LispVal] -> Eval LispVal }
 ```
@@ -95,7 +95,6 @@ To handle lexical scoping, the lambda function must enclose the environment pres
 Conceptually, the easiest way is to just bring the environment along with the function.
 For an implementation, the data constructor `Lambda` accepts  `EnvCtx`, which is the lexical environment, as well as `IFunc`, which is a Haskell function.
 You'll notice it takes its arguments as a list of `LispVal`, then returns an object of type `Eval LispVal`.  For more on `Eval`, read the next section.
-There's also a `deriving (Typeable)`, which is needed for error handling.  More on that later!
 
 ## Evaluation Monad
 (from [LispVal.hs](https://github.com/write-you-a-scheme-v2/scheme/tree/master/src/LispVal.hs))
@@ -116,7 +115,6 @@ newtype Eval a = Eval { unEval :: ReaderT EnvCtx IO a }
            , Applicative
            , MonadReader EnvCtx
            , MonadIO)
-
 ```
 
 For evaluation, we need to handle the context of a couple of things: the environment of variable/value bindings, exception handling, and IO.

--- a/src/LispVal.hs
+++ b/src/LispVal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module LispVal (
@@ -10,7 +9,6 @@ module LispVal (
   showVal,
 ) where
 
-import Data.Typeable (Typeable)
 import qualified Data.Text as T
 import qualified Data.Map as Map
 
@@ -27,7 +25,7 @@ data EnvCtx = EnvCtx
   } deriving (Eq)
 
 newtype Eval a = Eval { unEval :: ReaderT EnvCtx IO a }
-  deriving (Monad, Functor, Applicative, MonadReader EnvCtx,  MonadIO)
+  deriving (Monad, Functor, Applicative, MonadReader EnvCtx, MonadIO)
 
 data LispVal
   = Atom T.Text
@@ -38,13 +36,12 @@ data LispVal
   | Lambda IFunc EnvCtx
   | Nil
   | Bool Bool
-  deriving (Typeable,Eq)
+  deriving (Eq)
 
 instance Show LispVal where
   show = T.unpack . showVal
 
 data IFunc = IFunc { fn :: [LispVal] -> Eval LispVal }
-  deriving (Typeable)
 
 instance Eq IFunc where
  (==) _ _ = False
@@ -78,7 +75,6 @@ data LispException
   | Default LispVal
   | PError String -- from show anyway
   | IOError T.Text
-  deriving (Typeable)
 
 instance Exception LispException
 


### PR DESCRIPTION
* Cleaned up the filenames.
* Removed the mention of the non-existent `Pretty.hs`, as it was somewhat confusing.
* Deriving of `Typeable` is redundant since GHC 7.10, and the lts-16.17 resolver uses ghc-8.8.4. Moreover, I don't see `Typeable` actually used anywhere (perhaps it was meant to be used in the pretty-printing module?).

I've also noted there are some differences between the text and the sources:
*  In the docs `Eval` does not contain the `fenv` field (which may be confusing for the reader). I've not corrected this; need to read through `Eval.hs` to see what it is used for.
* `unwordsList` is inlined in the definition of `showVal` in the docs (but that's a minor one and makes the exposition clearer).